### PR TITLE
#4: Use i18n key for default label lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## [Unreleased]
 
+- Replaces `param_key` with `i18n_key` for attribute lookup in locale file
+
 ## [1.0.0] - 2022-03-23
 
 - Initial release

--- a/lib/katalyst/tables/frontend.rb
+++ b/lib/katalyst/tables/frontend.rb
@@ -17,7 +17,7 @@ module Katalyst
       def table_with(collection:, **options, &block)
         table_options = options.slice(:header, :object_name, :sort)
 
-        table_options[:object_name] ||= collection.try(:model_name)&.param_key
+        table_options[:object_name] ||= collection.try(:model_name)&.i18n_key
 
         html_options = html_options_for_table_with(**options)
 


### PR DESCRIPTION
Use `i18n_key` instead of `param_key` as default attribute lookup path.

Resolves https://github.com/katalyst/katalyst-tables/issues/4