### PR TITLE
Use HTML response when navigating between pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,8 +281,8 @@ def index
   table = Katalyst::Turbo::TableComponent.new(collection:, id: "people")
   
   respond_to do |format|
+    format.turbo_stream { render table } if self_referred?
     format.html { render locals: { table: table } }
-    format.turbo_stream { render table }
   end
 end
 ```

--- a/app/components/concerns/katalyst/tables/turbo_replaceable.rb
+++ b/app/components/concerns/katalyst/tables/turbo_replaceable.rb
@@ -47,10 +47,10 @@ module Katalyst
             component_class.alias_method(:vc_render_template_for, :render_template_for)
             component_class.class_eval <<-RUBY, __FILE__, __LINE__ + 1
             def render_template_for(variant = nil)
-              return vc_render_template_for(variant) unless turbo?
-              controller.respond_to do |format|
-                format.html { vc_render_template_for(variant) }
-                format.turbo_stream { turbo_stream.replace(id, vc_render_template_for(variant)) }
+              if turbo? && response.media_type.eql?("text/vnd.turbo-stream.html")
+                turbo_stream.replace(id, vc_render_template_for(variant))
+              else
+                vc_render_template_for(variant)
               end
             end
             RUBY

--- a/lib/katalyst/tables/backend.rb
+++ b/lib/katalyst/tables/backend.rb
@@ -27,6 +27,11 @@ module Katalyst
                 .apply(collection)
       end
 
+      def self_referred?
+        request.referer.present? && URI.parse(request.referer).path == request.path
+      end
+      alias self_refered? self_referred?
+
       included do
         class_attribute :_default_table_component, instance_accessor: false
       end


### PR DESCRIPTION
When redirecting after a turbostream request, turbo passes along the "turbo-stream" request as the response type to the new "get" request. Adding guards around when we should respond with a turbo replace response should ensure we always get a appropriate response.